### PR TITLE
Add workflow to automate CHANGELOG updates on release

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,30 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types:
+      - created
+      - released
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automatically update the CHANGELOG file upon each release. It ensures the CHANGELOG reflects the latest version and release notes, streamlining release management processes.