### PR TITLE
Add command to purge orphaned workspace invitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A customized version with the following things:
     - with a "workspace" terminology to handle a working context like a team or project
     - you can invite other users to work with in the same workspace
     - includes an architecture test as well
+    - command to purge old invitations: `php artisan workspace:purge-orphaned-invitations [--age=60]`
 
 ## Features
 

--- a/app-modules/workspace/src/Console/Commands/PurgeOrphanedInvitationsCommand.php
+++ b/app-modules/workspace/src/Console/Commands/PurgeOrphanedInvitationsCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Modules\Workspace\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Workspace\Models\WorkspaceInvitation;
+
+class PurgeOrphanedInvitationsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'workspace:purge-orphaned-invitations {--age=60 : Age in days}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Purge orphaned invitations';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $ageInDays = max(0, $this->option('age'));
+
+        $this->info('Purging all open invitations older than '.$ageInDays.' days...');
+
+        $deletedInvitations = WorkspaceInvitation::query()
+            ->where('created_at', '<', now()->subDays($ageInDays))
+            ->delete();
+
+        $this->info($deletedInvitations.' invitations were deleted.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app-modules/workspace/src/Console/Commands/PurgeOrphanedInvitationsCommand.php
+++ b/app-modules/workspace/src/Console/Commands/PurgeOrphanedInvitationsCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Modules\Workspace\Console\Commands;
 
 use Illuminate\Console\Command;


### PR DESCRIPTION
Introduce a new Artisan command `workspace:purge-orphaned-invitations` to delete old and unused workspace invitations. The command accepts an optional `--age` parameter (defaulting to 60 days) to specify the age of invitations to purge. Updated the README to document this new feature.